### PR TITLE
Bugfix

### DIFF
--- a/src/main/java/gr/seab/r2rml/entities/sql/SelectQuery.java
+++ b/src/main/java/gr/seab/r2rml/entities/sql/SelectQuery.java
@@ -89,7 +89,7 @@ public class SelectQuery {
 		String tokens[] = q.substring(start).split("\\s+");
 		
 		//if there are aliases
-		if (StringUtils.containsIgnoreCase(q.substring(start), "AS")) {
+		if (StringUtils.containsIgnoreCase(q.substring(start), " AS ")) {
 			for (int i = 0; i < tokens.length; i++) {
 				if ("AS".equalsIgnoreCase(tokens[i])) {
 					if (tokens[i+1].endsWith(",")) {


### PR DESCRIPTION
Without the space buffer on the "AS" table names that have 'as' inside are wrongly treated as aliases and indexOutOfBoundsException is thrown.

java.lang.IndexOutOfBoundsException: Index: 0, Size: 0
        at java.util.ArrayList.rangeCheck(Unknown Source)
        at java.util.ArrayList.get(Unknown Source)
        at gr.seab.r2rml.entities.sql.SelectQuery.createSelectFieldTable(SelectQuery.java:122)
        at gr.seab.r2rml.entities.sql.SelectQuery.createSelectFields(SelectQuery.java:67)
        at gr.seab.r2rml.entities.sql.SelectQuery.<init>(SelectQuery.java:34)
        at gr.seab.r2rml.beans.Parser.findLogicalTableViews(Parser.java:598)
        at gr.seab.r2rml.beans.Parser.parse(Parser.java:102)
        at gr.seab.r2rml.beans.Main.main(Main.java:83)
Exception in thread "main" java.lang.NullPointerException
        at gr.seab.r2rml.beans.Generator.createTriples(Generator.java:189)
        at gr.seab.r2rml.beans.Main.main(Main.java:93)