### PR TITLE
Support uuid SQL type

### DIFF
--- a/src/main/java/gr/seab/r2rml/beans/UtilImpl.java
+++ b/src/main/java/gr/seab/r2rml/beans/UtilImpl.java
@@ -304,7 +304,8 @@ public class UtilImpl implements Util {
 				|| sqlDataType.contains("varbit")
 				|| sqlDataType.contains("cidr")
 				|| sqlDataType.contains("inet")
-				|| sqlDataType.contains("macaddr")) {
+				|| sqlDataType.contains("macaddr")
+				|| sqlDataType.contains("uuid")) {
     		//return XSDDatatype.XSDstring;
 			//if the sql field type is a string, it is ok to omit the xsd datatype from the result
 			return null;


### PR DESCRIPTION
Postgres (at least) supports the type "uuid", which is used on the MusicBrainz database. Without this change, r2rml-parser fails to run on the MusicBrainz database - with it, it worked fine for me.