### PR TITLE
fixed iri as template result getting prefixed with default.namespace

### DIFF
--- a/src/main/java/gr/seab/r2rml/beans/UtilImpl.java
+++ b/src/main/java/gr/seab/r2rml/beans/UtilImpl.java
@@ -76,7 +76,7 @@ public class UtilImpl implements Util {
 				}
 			}
 			
-			if (template.getTermType() == TermType.IRI && !template.isUri()) {
+			if (result != null && template.getTermType() == TermType.IRI && !isUri(result, template.getModel())) {
 				//log.info("Processing URI template with namespace " + template.getText());
 				if (encodeURLs) {
 					try {
@@ -87,6 +87,16 @@ public class UtilImpl implements Util {
 					}
 				} else {
 					result = template.getNamespace() + "/" + result;
+				}
+			}
+			if(result != null && template.getTermType() == TermType.IRI && isUri(result, template.getModel())){
+				if (encodeURLs) {
+					try {
+						result = URLEncoder.encode(result, "UTF-8");
+					} catch (UnsupportedEncodingException e) {
+						log.error("An error occurred!", e);
+						System.exit(1);
+					}
 				}
 			}
 			
@@ -443,6 +453,20 @@ public class UtilImpl implements Util {
 			log.error(ex.getMessage());
 		}
 		return digest;
+	}
+
+	public static boolean isUri(String s, Model model){
+
+			for (String key : model.getNsPrefixMap().keySet()) {
+				//log.info("checking if " + s + " contains '" + key + ":' or " + model.getNsPrefixMap().get(key));
+				if (s.contains(key + ":") || s.contains(model.getNsPrefixMap().get(key))) return true;
+			}
+
+			if (s.contains("http")) {
+				return true;
+			} else {
+				return false;
+			}
 	}
 	
 }

--- a/src/main/java/gr/seab/r2rml/entities/Template.java
+++ b/src/main/java/gr/seab/r2rml/entities/Template.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 
 import com.hp.hpl.jena.rdf.model.Literal;
 import com.hp.hpl.jena.rdf.model.Model;
+import gr.seab.r2rml.beans.UtilImpl;
 
 /**
  * The template is a component of the form http://data.example.com/film/{film_id}. Encloses fields in brackets.
@@ -77,18 +78,7 @@ public class Template {
 	}
 	
 	public boolean isUri() {
-		String s = text;
-		
-		for (String key : model.getNsPrefixMap().keySet()) {
-			//log.info("checking if " + s + " contains '" + key + ":' or " + model.getNsPrefixMap().get(key));
-			if (s.contains(key + ":") || s.contains(model.getNsPrefixMap().get(key))) return true;
-		}
-		
-		if (s.contains("http")) {
-			return true;
-		} else {
-			return false;
-		}
+		return UtilImpl.isUri(this.text, model);
 	}
 	
 	public String getText() {


### PR DESCRIPTION
refs nkons/r2rml-parser#37

Implementation Note:
In UtilImpl.java : Instead of testing if the template itself contains a IRI I'm testing if the result is actually already an IRI. If not I'm prefixing the result with the default.namespace.
Template.java : I moved the logic to test if a string is actually an IRI to UtilImpl.java